### PR TITLE
Fixing a fontspec / XeTeX / macOS font issue

### DIFF
--- a/Fundamentals_of_Matrix_Algebra.tex
+++ b/Fundamentals_of_Matrix_Algebra.tex
@@ -53,13 +53,26 @@ textwidth=345pt, inner=1in,includeheadfoot]{geometry}}{}
 %\usepackage{fontspec}
 \usepackage{mathspec}
 
-\setallmainfonts[Mapping=tex-text]{Calibri}
-\setmainfont[Mapping=tex-text]{Calibri}
-\setsansfont[Mapping=tex-text]{Calibri}
+\setallmainfonts(Digits,Latin)[Ligatures=TeX]{Calibri}
+\setsansfont[Ligatures=TeX]{Calibri}
+\setmathsfont(Greek)[Ligatures=TeX]{[lmroman10-italic]}
 
-\setmathsfont(Greek){[cmmi10]}
+\newfontface\calligraphyfont{Lucida Calligraphy.ttf}[Scale=2.5]
+\newfontfamily\lmroman{lmroman10}[
+  Extension= .otf ,
+  UprightFont = *-regular ,
+  ItalicFont = *-italic ,
+  SlantedFont = lmromanslant10-regular ,
+  BoldFont = *-bold ,
+  BoldItalicFont = *-bolditalic ,
+  SmallCapsFont = lmromancaps10-regular
+]
+
+\colorlet{gregblue}{blue!30!black}
 
 
+\newcommand{\versionnum}{3.1110}
+\newcommand{\edition}{Fourth}
 
 \begin{document}
 
@@ -83,9 +96,6 @@ textwidth=345pt, inner=1in,includeheadfoot]{geometry}}{}
 
 \normalem
 
-%%%\setallmainfonts[Mapping=tex-text]{Calibri}
-%%%%\setmainfont[Mapping=tex-text]{Calibri}
-%%%%\setsansfont[Mapping=tex-text]{Calibri}
 \sffamily
 
 
@@ -102,7 +112,7 @@ textwidth=345pt, inner=1in,includeheadfoot]{geometry}}{}
 \frontmatter
 
 \title{\textsc{Fundamentals of Matrix Algebra}\\
-{\small Version 2.1011}}
+{\small Version \versionnum}}
 \author{Gregory N. Hartman, Ph.D.}
 \date{}
 

--- a/cover/front_cover_in_text.tex
+++ b/cover/front_cover_in_text.tex
@@ -61,15 +61,15 @@ opacity=0.4]{#2};
 }
 
 %\node[yshift=5.5cm,scale=4,opacity=.5,blue] at (current page.center) {\Huge \textit{of}};
-\node[yshift=5.5cm,scale=4,opacity=.5,blue] at (current page.center) {\fontspec[Scale=2.5]{Lucida Calligraphy}\itshape of};
+\node[yshift=5.5cm,scale=4,opacity=.5,blue] at (current page.center) {\calligraphyfont of};
 \ifthenelse{\boolean{ipadsize}}
-{\node[yshift=7cm,scale=1.9,blue!30!black] at (current page.center) {\fontspec[Scale=2.5]{[cmcsc10]} Fundamentals};
-\node[yshift=4cm,scale=1.9,blue!30!black] at (current page.center) {\fontspec[Scale=2.5]{[cmcsc10]} Matrix Algebra};
-\node[xshift=-1cm,yshift=2.5cm,scale=1,blue!30!black,,left color=yellow!30,right color=yellow] at (current page.center) {\fontspec[Scale=1]{[cmsl10]} \ \hskip 14cm Second Edition};}
-{\node[yshift=7cm,scale=2,blue!30!black] at (current page.center) {\fontspec[Scale=2.5]{[cmcsc10]} Fundamentals};
-\node[yshift=4cm,scale=2,blue!30!black] at (current page.center) {\fontspec[Scale=2.5]{[cmcsc10]} Matrix Algebra};
-\node[xshift=-1cm,yshift=2.5cm,scale=1,blue!30!black,left color=blue!10,right color=blue!50] at (current page.center) {\fontspec[Scale=1]{[cmsl10]} \ \hskip 14cm Third Edition};}
-%\node[xshift=3.45in,yshift=2.5cm,scale=1,blue!30!black,left color=yellow!30,right color=yellow] at (current page.center) {\fontspec[Scale=1]{[cmsl10]} \ \hskip 5.25in Second Edition};
+{\node[yshift=7cm,scale=3.9, color=gregblue] at (current page.center) {\lmroman \textsc{Fundamentals}};
+\node[yshift=4cm,scale=3.9, color=gregblue] at (current page.center) {\lmroman \textsc{Matrix Algebra}};
+\node[xshift=-1cm,yshift=2.5cm,scale=1,color=gregblue,,left color=yellow!30,right color=yellow] at (current page.center) {\lmroman \itshape \ \hskip 14cm Second Edition};}
+{\node[yshift=7cm,scale=5,color=gregblue] at (current page.center) {\lmroman \textsc{Fundamentals}};
+\node[yshift=4cm,scale=5,color=gregblue] at (current page.center) {\lmroman \textsc{Matrix Algebra}};
+\node[xshift=-1cm,yshift=2.5cm,scale=1,color=gregblue,left color=blue!10,right color=blue!50] at (current page.center) {\lmroman \itshape \ \hskip 14cm \edition{} Edition};}
+%\node[xshift=3.45in,yshift=2.5cm,scale=1,color=gregblue,left color=yellow!30,right color=yellow] at (current page.center) {\lmroman \itshape \ \hskip 5.25in Second Edition};
 
 \draw ($(current page.center)!.25!(current page.south)$) node  {
 \begin{tikzpicture}[scale=5,>=latex]
@@ -84,6 +84,6 @@ opacity=0.4]{#2};
 
 %\nodeshadowed [at={($(current page.center)!.75!(current page.south)$)}] {\huge $\left[ \begin{array}{cc} \cos \theta & -\sin \theta \\ \sin \theta & \cos \theta \end{array}\right] $};
 
-\draw (4.5in,-8in) node [scale=1,blue!30!black] {\fontspec[Scale=2]{[cmr10]} Gregory Hartman};
+\draw (4.5in,-8in) node [scale=2,color=gregblue] {\lmroman Gregory Hartman};
 
 \end{tikzpicture}


### PR DESCRIPTION
Also streamlining the code for the cover page.

Brief explanation: 

Per the [fontspec manual](https://texdoc.org/serve/fontspec/0), there is a new problem with rendering specific fonts on macOS machines in XeTeX. As a result, I made some changes that streamline the code on the cover page, fix the issue (affecting many pages, not just the cover page), and do not require OS-specific accommodations.
 
![fontspec_manual_p_56](https://user-images.githubusercontent.com/1970982/128072698-937d8397-8953-42eb-a238-479b7f2bc34b.png)
