### PR TITLE
Simplifying front cover by swapping "of" font

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@
 #*.log
 *.tmp
 *.tps
+
+## macOS Finder metadata
+*.DS_Store
 #
 ## Don't skip these files
 !CalculusI.aux

--- a/Fundamentals_of_Matrix_Algebra.tex
+++ b/Fundamentals_of_Matrix_Algebra.tex
@@ -57,7 +57,7 @@ textwidth=345pt, inner=1in,includeheadfoot]{geometry}}{}
 \setsansfont[Ligatures=TeX]{Calibri}
 \setmathsfont(Greek)[Ligatures=TeX]{[lmroman10-italic]}
 
-\newfontface\calligraphyfont{Lucida Calligraphy.ttf}[Scale=2.5]
+\newfontface\calligraphyfont{texgyrechorus-mediumitalic.otf}[Scale=3.2]
 \newfontfamily\lmroman{lmroman10}[
   Extension= .otf ,
   UprightFont = *-regular ,

--- a/cover/front_cover_in_text.tex
+++ b/cover/front_cover_in_text.tex
@@ -50,7 +50,7 @@
 %\shade [bottom color=red!50!black,top color=red!70!black!50]
 %(top left) rectangle (bot right);
 
-\shade [bottom color=red!50!black,top color=red!70!black!50]
+\shade [bottom color=red!60!gray,top color=red!70!black!50]
 (top left) rectangle (bot right);
 
 


### PR DESCRIPTION
Lucida Calligraphy [Italic] substituted with TeX Gyre Chorus
and cover background color updated to slightly improve readability.
Added one line to .gitignore for macOS Finder files, ".DS_Store".

Updated font:
<img width="1046" alt="new_tex_gyre_chorus_font" src="https://user-images.githubusercontent.com/1970982/128528542-4b691ace-07be-44bf-8b06-5fdac61563eb.png">


Original font:
<img width="1089" alt="third_edition_lucida_calligraphy_font" src="https://user-images.githubusercontent.com/1970982/128528831-92eb358f-a0e0-4cea-a167-9123c0391b64.png">
